### PR TITLE
fix compilation with boost::filesystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
             - libx11-dev
             - libxft-dev
             - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-thread-dev
+            - libboost-chrono-dev
           sources: 
             - ubuntu-toolchain-r-test
             

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,15 +206,16 @@ elseif (NANA_CMAKE_STD_FILESYSTEM_FORCE)
     add_definitions(-DSTD_FILESYSTEM_FORCE)
 elseif (NANA_CMAKE_FIND_BOOST_FILESYSTEM OR NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     if (NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
-        add_definitions(-DNANA_BOOST_FILESYSTEM_FORCE)
+        add_definitions(-DBOOST_FILESYSTEM_FORCE)
     endif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
-    # https://cmake.org/cmake/help/git-master/module/FindBoost.html
-    # Implicit dependencies such as Boost::filesystem requiring Boost::system will be automatically detected and satisfied,
-    # even if system is not specified when using find_package and if Boost::system is not added to target_link_libraries.
-    # If using Boost::thread, then Thread::Thread will also be added automatically.
-    find_package(Boost COMPONENTS filesystem)
+    # Some CMake versions don't list missing boost dependencies, so we need to add them manually
+    # - libboost_system is needed for HelloWorld demo at least
+    # - libboost_thread is needed for threading demo
+    # - libboost_chrono is needed for thread_pool demo
+    # Boost_THREADAPI should be set to correct suffix (empty, or win32, or pthread)
+    find_package(Boost COMPONENTS filesystem system thread chrono)
     if (Boost_FOUND)
-        add_definitions(-DNANA_BOOST_FILESYSTEM_AVAILABLE)
+        add_definitions(-DBOOST_FILESYSTEM_AVAILABLE)
         include_directories(SYSTEM "${Boost_INCLUDE_DIR}")
         set(NANA_LINKS "${NANA_LINKS} ${Boost_LIBRARIES}")    ######  FIRST !!!!!!!!!!!!!!!!!    add   is not first
     endif (Boost_FOUND)


### PR DESCRIPTION
see cnjinhao/nana#281 for related changes.

Travis build succeeded with this PR and changes to nana lib applied:
https://travis-ci.org/pavelxdd/nana/builds/308570743

CMakeLists.txt:
---------------
CMake exported definitions with wrong name prefixes when compiling with Boost Filesystem, and nana used internal implementation of filesystem

Added boost system and thread libs to find_package, this comment from cmake documentation doesn't seem to be always true for all versions of CMake and Boost, also Travis build failed with the message that boost_system wasn't specified in linker flags, and threading demo failed due to missing linking to boost_thread lib.
Chrono is needed for thread_pool demo.

demo programs:
--------------
boost::filesystem::path doesn't have a generic_u8string method, so changed it to nana::to_utf8(generic_wstring) in this demo.

boost::filesystem::directory_iterator doesn't have begin and end methods, so changed a for-loop to make it work.